### PR TITLE
Fix download, Fix darwin install

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -11,7 +11,29 @@ fail() {
   exit 1
 }
 
+# adapted from https://github.com/asdf-community/asdf-hashicorp/blob/master/bin/install
+get_arch() {
+  local -r machine="$(uname -m)"
+  local -r upper_toolname=$(echo "${TOOL_NAME//-/_}" | tr '[:lower:]' '[:upper:]')
+  local -r tool_specific_arch_override="ASDF_PODMAN_OVERWRITE_ARCH_${upper_toolname}"
+
+  OVERWRITE_ARCH=${!tool_specific_arch_override:-${ASDF_PODMAN_OVERWRITE_ARCH:-"false"}}
+
+  if [[ ${OVERWRITE_ARCH} != "false" ]]; then
+    echo "${OVERWRITE_ARCH}"
+  elif [[ ${machine} == "arm64" ]] || [[ ${machine} == "aarch64" ]]; then
+    echo "arm64"
+  elif [[ ${machine} == *"arm"* ]] || [[ ${machine} == *"aarch"* ]]; then
+    echo "arm"
+  elif [[ ${machine} == *"386"* ]]; then
+    echo "386"
+  else
+    echo "amd64"
+  fi
+}
+
 platform=$(uname -s | awk '{print tolower($0)}')
+arch="$(get_arch)"
 curl_opts=(-fsSL)
 
 # NOTE: You might want to remove this if podman is not hosted on GitHub releases.
@@ -41,10 +63,10 @@ download_release() {
 
   case $platform in
   darwin)
-    url="$GH_REPO/releases/download/v${version}/podman-remote-release-${platform}.zip"
+    url="$GH_REPO/releases/download/v${version}/podman-remote-release-${platform}_${arch}.zip"
     ;;
   linux)
-    url="$GH_REPO/releases/download/v${version}/podman-remote-static.tar.gz"
+    url="$GH_REPO/releases/download/v${version}/podman-remote-static_${arch}.tar.gz"
     ;;
   *)
     echo "Unknown platform: ${platform}"
@@ -70,7 +92,7 @@ install_version() {
   if [ "$platform" == "darwin" ]; then
     (
       mkdir -p "$install_path/bin"
-      cp -r "$ASDF_DOWNLOAD_PATH"/podman "$binpath"
+      cp -r "$ASDF_DOWNLOAD_PATH"/usr/bin/podman "$binpath"
 
       mkdir -p "$manpath"/man1
       cp -r "$ASDF_DOWNLOAD_PATH"/docs/*.1 "$manpath"/man1


### PR DESCRIPTION
The download step was previously broken as podman now uses a different naming scheme for release archives that contains a trailing string for the architecture in the filenames `*_<ARCH>.*`, this is now fixed by detecting the architecture and using it in the filename.

The install step was broken for darwin as the podman release archive has changed folders structure for the position of the binary, this is now fixed by taking that into account